### PR TITLE
Add metadata api and set llvm 20 as default

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
         run:
           go test -v -tags=llvm${{ matrix.llvm }}
       - name: Test default LLVM
-        if: matrix.llvm == 19
+        if: matrix.llvm == 20
         run:
           go test -v
   test-linux:
@@ -57,6 +57,6 @@ jobs:
         run:
           go test -v -tags=llvm${{ matrix.llvm }}
       - name: Test default LLVM
-        if: matrix.llvm == 19
+        if: matrix.llvm == 20
         run:
           go test -v

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/goplus/llvm
 
-go 1.14
+go 1.22

--- a/ir.go
+++ b/ir.go
@@ -577,6 +577,8 @@ func (c Context) X86FP80Type() (t Type)  { t.C = C.LLVMX86FP80TypeInContext(c.C)
 func (c Context) FP128Type() (t Type)    { t.C = C.LLVMFP128TypeInContext(c.C); return }
 func (c Context) PPCFP128Type() (t Type) { t.C = C.LLVMPPCFP128TypeInContext(c.C); return }
 
+func (c Context) MetadataType() (t Type) { t.C = C.LLVMMetadataTypeInContext(c.C); return }
+
 // Operations on function types
 func FunctionType(returnType Type, paramTypes []Type, isVarArg bool) (t Type) {
 	var pt *C.LLVMTypeRef
@@ -826,6 +828,10 @@ func (c Context) MDNode(mds []Metadata) (md Metadata) {
 }
 func (v Value) ConstantAsMetadata() (md Metadata) {
 	md.C = C.LLVMConstantAsMetadata(v.C)
+	return
+}
+func (c Context) MetadataAsValue(md Metadata) (v Value) {
+	v.C = C.LLVMMetadataAsValue(c.C, md.C)
 	return
 }
 

--- a/llvm_config_llvm19.go
+++ b/llvm_config_llvm19.go
@@ -1,4 +1,4 @@
-//go:build !byollvm && !llvm14 && !llvm15 && !llvm16 && !llvm17 && !llvm18 && !llvm20 && !llvm21
+//go:build !byollvm && llvm19
 
 package llvm
 

--- a/llvm_config_llvm20.go
+++ b/llvm_config_llvm20.go
@@ -1,4 +1,4 @@
-//go:build !byollvm && llvm20
+//go:build !byollvm && !llvm14 && !llvm15 && !llvm16 && !llvm17 && !llvm18 && !llvm19 && !llvm21
 
 package llvm
 


### PR DESCRIPTION
Summary:
- add metadata APIs in IR bindings
- switch default LLVM version from 19 to 20
- keep LLVM 19/20 config files aligned with the new default

Test:
- not run