### PR TITLE
llvm: add full LTO bitcode writer

### DIFF
--- a/backports.cpp
+++ b/backports.cpp
@@ -1,5 +1,8 @@
 
 #include "backports.h"
+#include "llvm/Analysis/ModuleSummaryAnalysis.h"
+#include "llvm/Analysis/ProfileSummaryInfo.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/Instructions.h"
 #if LLVM_VERSION_MAJOR >= 16
 #include "llvm/IR/PassManager.h"
@@ -46,6 +49,19 @@ LLVMMemoryBufferRef LLVMGoWriteThinLTOBitcodeToMemoryBuffer(LLVMModuleRef M) {
   PM.add(createWriteThinLTOBitcodePass(OS));
   PM.run(*llvm::unwrap(M));
 #endif
+  return llvm::wrap(llvm::MemoryBuffer::getMemBufferCopy(OS.str()).release());
+}
+
+LLVMMemoryBufferRef LLVMGoWriteFullLTOBitcodeToMemoryBuffer(LLVMModuleRef M) {
+  std::string Data;
+  llvm::raw_string_ostream OS(Data);
+  llvm::Module *Mod = llvm::unwrap(M);
+  Mod->addModuleFlag(llvm::Module::Error, "ThinLTO", uint32_t(0));
+  llvm::ProfileSummaryInfo PSI(*Mod);
+  llvm::ModuleSummaryIndex Index =
+      llvm::buildModuleSummaryIndex(*Mod, nullptr, &PSI);
+  Index.setEnableSplitLTOUnit();
+  llvm::WriteBitcodeToFile(*Mod, OS, false, &Index, false);
   return llvm::wrap(llvm::MemoryBuffer::getMemBufferCopy(OS.str()).release());
 }
 

--- a/backports.h
+++ b/backports.h
@@ -10,6 +10,8 @@ void LLVMGlobalObjectAddMetadata(LLVMValueRef objValue, unsigned KindID, LLVMMet
 
 LLVMMemoryBufferRef LLVMGoWriteThinLTOBitcodeToMemoryBuffer(LLVMModuleRef M);
 
+LLVMMemoryBufferRef LLVMGoWriteFullLTOBitcodeToMemoryBuffer(LLVMModuleRef M);
+
 void LLVMGoDIBuilderInsertDbgValueRecordAtEnd(
     LLVMDIBuilderRef Builder, LLVMValueRef Val, LLVMMetadataRef VarInfo,
     LLVMMetadataRef Expr, LLVMMetadataRef DebugLoc, LLVMBasicBlockRef Block);

--- a/bitwriter.go
+++ b/bitwriter.go
@@ -36,6 +36,11 @@ func WriteBitcodeToMemoryBuffer(m Module) MemoryBuffer {
 	return MemoryBuffer{mb}
 }
 
+func WriteFullLTOBitcodeToMemoryBuffer(m Module) MemoryBuffer {
+	mb := C.LLVMGoWriteFullLTOBitcodeToMemoryBuffer(m.C)
+	return MemoryBuffer{mb}
+}
+
 func WriteThinLTOBitcodeToMemoryBuffer(m Module) MemoryBuffer {
 	mb := C.LLVMGoWriteThinLTOBitcodeToMemoryBuffer(m.C)
 	return MemoryBuffer{mb}

--- a/bitwriter_test.go
+++ b/bitwriter_test.go
@@ -1,0 +1,29 @@
+package llvm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWriteFullLTOBitcodeToMemoryBufferAddsFullLTOFlag(t *testing.T) {
+	ctx := NewContext()
+	mod := ctx.NewModule("full_lto")
+	defer mod.Dispose()
+
+	fnTy := FunctionType(ctx.Int32Type(), nil, false)
+	AddFunction(mod, "main", fnTy)
+
+	buf := WriteFullLTOBitcodeToMemoryBuffer(mod)
+	defer buf.Dispose()
+	if buf.IsNil() {
+		t.Fatal("WriteFullLTOBitcodeToMemoryBuffer returned nil buffer")
+	}
+
+	ir := mod.String()
+	if !strings.Contains(ir, `i32 1, !"ThinLTO", i32 0`) {
+		t.Fatalf("missing full LTO ThinLTO module flag:\n%s", ir)
+	}
+	if strings.Contains(ir, `"EnableSplitLTOUnit"`) {
+		t.Fatalf("split-unit state should be controlled by the summary index, not a module flag:\n%s", ir)
+	}
+}

--- a/ir.go
+++ b/ir.go
@@ -593,6 +593,8 @@ func (c Context) X86FP80Type() (t Type)  { t.C = C.LLVMX86FP80TypeInContext(c.C)
 func (c Context) FP128Type() (t Type)    { t.C = C.LLVMFP128TypeInContext(c.C); return }
 func (c Context) PPCFP128Type() (t Type) { t.C = C.LLVMPPCFP128TypeInContext(c.C); return }
 
+func (c Context) MetadataType() (t Type) { t.C = C.LLVMMetadataTypeInContext(c.C); return }
+
 // Operations on function types
 func FunctionType(returnType Type, paramTypes []Type, isVarArg bool) (t Type) {
 	var pt *C.LLVMTypeRef
@@ -862,6 +864,10 @@ func (v Value) MDString() string {
 }
 func (v Value) ConstantAsMetadata() (md Metadata) {
 	md.C = C.LLVMConstantAsMetadata(v.C)
+	return
+}
+func (c Context) MetadataAsValue(md Metadata) (v Value) {
+	v.C = C.LLVMMetadataAsValue(c.C, md.C)
 	return
 }
 


### PR DESCRIPTION
## Summary

- add `WriteFullLTOBitcodeToMemoryBuffer` and the LLVM C++ shim used to emit full LTO bitcode
- build a module summary index for full LTO output and mark the module with `ThinLTO = 0` when missing
- expose metadata type/value helpers needed by llgo LTO integration
- add coverage for the full LTO bitcode writer behavior

## Why

llgo LTO support needs a full LTO bitcode path alongside the existing ThinLTO writer. This adds the go-llvm API surface and LLVM backport glue needed by llgo to produce full LTO-compatible bitcode.

## Validation

- `go test ./...`