### PR TITLE
llvm: add intrinsic call bindings

### DIFF
--- a/IRBindings.cpp
+++ b/IRBindings.cpp
@@ -16,6 +16,7 @@
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 
@@ -84,4 +85,12 @@ LLVMValueRef LLVMGoGetInlineAsm(LLVMTypeRef Ty, char *AsmString,
                           ConstraintsSize, HasSideEffects,
                           IsAlignStack,
                           Dialect, CanThrow);
+}
+
+LLVMValueRef LLVMGoBuildIntrinsicCall(LLVMBuilderRef B, LLVMTypeRef RetTy,
+                                      unsigned ID, LLVMValueRef *Args,
+                                      unsigned Count, const char *Name) {
+  return wrap(unwrap(B)->CreateIntrinsic(
+      unwrap(RetTy), static_cast<Intrinsic::ID>(ID),
+      ArrayRef<Value *>(unwrap(Args), Count), nullptr, Name));
 }

--- a/IRBindings.cpp
+++ b/IRBindings.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "IRBindings.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/IR/DebugInfoMetadata.h"
@@ -90,7 +91,23 @@ LLVMValueRef LLVMGoGetInlineAsm(LLVMTypeRef Ty, char *AsmString,
 LLVMValueRef LLVMGoBuildIntrinsicCall(LLVMBuilderRef B, LLVMTypeRef RetTy,
                                       unsigned ID, LLVMValueRef *Args,
                                       unsigned Count, const char *Name) {
-  return wrap(unwrap(B)->CreateIntrinsic(
-      unwrap(RetTy), static_cast<Intrinsic::ID>(ID),
-      ArrayRef<Value *>(unwrap(Args), Count), nullptr, Name));
+  Intrinsic::ID IntrinsicID = static_cast<Intrinsic::ID>(ID);
+  ArrayRef<Value *> UnwrappedArgs(unwrap(Args), Count);
+  SmallVector<Type *, 8> ParamTys;
+  SmallVector<Type *, 8> OverloadTys;
+  SmallVector<Intrinsic::IITDescriptor, 8> Infos;
+
+  ParamTys.reserve(Count);
+  for (Value *Arg : UnwrappedArgs)
+    ParamTys.push_back(Arg->getType());
+
+  FunctionType *FTy = FunctionType::get(unwrap(RetTy), ParamTys, false);
+  Intrinsic::getIntrinsicInfoTableEntries(IntrinsicID, Infos);
+  ArrayRef<Intrinsic::IITDescriptor> InfoRef(Infos);
+  if (Intrinsic::matchIntrinsicSignature(FTy, InfoRef, OverloadTys) !=
+      Intrinsic::MatchIntrinsicTypes_Match)
+    return nullptr;
+
+  return wrap(unwrap(B)->CreateIntrinsic(IntrinsicID, OverloadTys,
+                                         UnwrappedArgs, nullptr, Name));
 }

--- a/IRBindings.h
+++ b/IRBindings.h
@@ -55,6 +55,10 @@ LLVMValueRef LLVMGoGetInlineAsm(LLVMTypeRef Ty, char *AsmString,
                                 LLVMBool IsAlignStack,
                                 LLVMInlineAsmDialect Dialect, LLVMBool CanThrow);
 
+LLVMValueRef LLVMGoBuildIntrinsicCall(LLVMBuilderRef B, LLVMTypeRef RetTy,
+                                      unsigned ID, LLVMValueRef *Args,
+                                      unsigned Count, const char *Name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ir.go
+++ b/ir.go
@@ -385,6 +385,13 @@ func MDKindID(name string) (id int) {
 	return
 }
 
+func LookupIntrinsicID(name string) (id int) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	id = int(C.LLVMLookupIntrinsicID(cname, C.size_t(len(name))))
+	return
+}
+
 //-------------------------------------------------------------------------
 // llvm.Attribute
 //-------------------------------------------------------------------------
@@ -1952,6 +1959,14 @@ func (b Builder) CreateCall(t Type, fn Value, args []Value, name string) (v Valu
 	defer C.free(unsafe.Pointer(cname))
 	ptr, nvals := llvmValueRefs(args)
 	v.C = C.LLVMBuildCall2(b.C, t.C, fn.C, ptr, nvals, cname)
+	return
+}
+
+func (b Builder) CreateIntrinsic(ret Type, id int, args []Value, name string) (v Value) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	ptr, nvals := llvmValueRefs(args)
+	v.C = C.LLVMGoBuildIntrinsicCall(b.C, ret.C, C.unsigned(id), ptr, nvals, cname)
 	return
 }
 

--- a/ir_test.go
+++ b/ir_test.go
@@ -145,6 +145,36 @@ func TestDebugLoc(t *testing.T) {
 	}
 }
 
+func TestIntrinsicBindings(t *testing.T) {
+	ctx := NewContext()
+	mod := ctx.NewModule("")
+	defer mod.Dispose()
+
+	memsetID := LookupIntrinsicID("llvm.memset")
+	if memsetID == 0 {
+		t.Fatal("could not look up llvm.memset intrinsic")
+	}
+	ptrTy := PointerType(ctx.Int8Type(), 0)
+	fnTy := FunctionType(ctx.VoidType(), []Type{ptrTy}, false)
+	fn := AddFunction(mod, "use_memset", fnTy)
+	builder := ctx.NewBuilder()
+	defer builder.Dispose()
+	builder.SetInsertPointAtEnd(ctx.AddBasicBlock(fn, "entry"))
+	call := builder.CreateIntrinsic(ctx.VoidType(), memsetID, []Value{
+		fn.Param(0),
+		ConstInt(ctx.Int8Type(), 0, false),
+		ConstInt(ctx.Int64Type(), 8, false),
+		ConstInt(ctx.Int1Type(), 0, false),
+	}, "")
+	builder.CreateRetVoid()
+	if got := call.CalledValue().Name(); got != "llvm.memset.p0.i64" {
+		t.Fatalf("got intrinsic callee %q, want llvm.memset.p0.i64", got)
+	}
+	if err := VerifyModule(mod, ReturnStatusAction); err != nil {
+		t.Fatalf("module with intrinsic call should verify: %v", err)
+	}
+}
+
 func TestSubtypes(t *testing.T) {
 	cont := NewContext()
 	defer cont.Dispose()

--- a/ir_test.go
+++ b/ir_test.go
@@ -167,8 +167,8 @@ func TestIntrinsicBindings(t *testing.T) {
 		ConstInt(ctx.Int1Type(), 0, false),
 	}, "")
 	builder.CreateRetVoid()
-	if got := call.CalledValue().Name(); got != "llvm.memset.p0.i64" {
-		t.Fatalf("got intrinsic callee %q, want llvm.memset.p0.i64", got)
+	if got := call.CalledValue().IntrinsicID(); got != memsetID {
+		t.Fatalf("got intrinsic ID %d, want %d", got, memsetID)
 	}
 	if err := VerifyModule(mod, ReturnStatusAction); err != nil {
 		t.Fatalf("module with intrinsic call should verify: %v", err)


### PR DESCRIPTION
## Summary

- expose `LLVMLookupIntrinsicID` through Go as `LookupIntrinsicID`
- add a Go builder binding for constructing LLVM intrinsic calls
- cover the binding with a `llvm.memset` intrinsic verification test

## Validation

- `go test ./...`
