### PR TITLE
llvm: add LLVM 22 build configuration and CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        llvm: [14, 15, 16, 17, 18, 19, 20, 21]
+        llvm: [14, 15, 16, 17, 18, 19, 20, 21, 22]
         go-version: [1.18.x, 1.21.x, 1.22.x]
     steps:
       - name: Checkout
@@ -24,7 +24,7 @@ jobs:
       #  run: brew update
       # Optional step when a LLVM version is very new.
       - name: Update Homebrew
-        if: matrix.llvm == 21
+        if: matrix.llvm == 22
         run: brew update
       - name: Install LLVM
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm@${{ matrix.llvm }}
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        llvm: [14, 15, 16, 17, 18, 19, 20, 21]
+        llvm: [14, 15, 16, 17, 18, 19, 20, 21, 22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.markdown
+++ b/README.markdown
@@ -12,12 +12,12 @@ This library provides bindings to a system-installed LLVM.
 
 Currently supported:
 
-  * LLVM 20, 19, 18, 17, 16, 15 and 14 from [apt.llvm.org](http://apt.llvm.org/) on Debian/Ubuntu.
-  * LLVM 20, 19, 18, 17, 16, 15 and 14 from Homebrew on macOS.
+  * LLVM 22, 21, 20, 19, 18, 17, 16, 15 and 14 from [apt.llvm.org](http://apt.llvm.org/) on Debian/Ubuntu.
+  * LLVM 22, 21, 20, 19, 18, 17, 16, 15 and 14 from Homebrew on macOS.
   * Any of the above versions with a manually built LLVM through the `byollvm` build tag. You need to set up `CFLAGS`/`LDFLAGS` etc yourself in this case.
 
-You can select the LLVM version using a build tag, for example `-tags=llvm17`
-to use LLVM 17.
+You can select the LLVM version using a build tag, for example `-tags=llvm22`
+to use LLVM 22.
 
 ## Usage
 
@@ -25,7 +25,7 @@ If you have a supported LLVM installation, you should be able to do a simple `go
 
     go get github.com/xgo-dev/llvm
 
-You can use build tags to select a LLVM version. For example, use `-tags=llvm15` to select LLVM 15. Setting a build tag for a LLVM version that is not supported will be ignored.
+You can use build tags to select a LLVM version. For example, use `-tags=llvm22` to select LLVM 22. Setting a build tag for a LLVM version that is not supported will be ignored.
 
 ## License
 

--- a/llvm_config_llvm19.go
+++ b/llvm_config_llvm19.go
@@ -1,4 +1,4 @@
-//go:build !byollvm && !llvm14 && !llvm15 && !llvm16 && !llvm17 && !llvm18 && !llvm20 && !llvm21
+//go:build !byollvm && !llvm14 && !llvm15 && !llvm16 && !llvm17 && !llvm18 && !llvm20 && !llvm21 && !llvm22
 
 package llvm
 

--- a/llvm_config_llvm22.go
+++ b/llvm_config_llvm22.go
@@ -1,0 +1,19 @@
+//go:build !byollvm && llvm22
+
+package llvm
+
+// #cgo darwin,amd64 CPPFLAGS: -I/usr/local/opt/llvm@22/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo darwin,amd64 CXXFLAGS: -std=c++17
+// #cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/llvm@22/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lm
+// #cgo darwin,arm64 CPPFLAGS: -I/opt/homebrew/opt/llvm@22/include   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo darwin,arm64 CXXFLAGS: -std=c++17
+// #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@22/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM -lz -lm
+// #cgo freebsd      CPPFLAGS: -I/usr/local/llvm22/include -I/usr/local/llvm22/include/llvm-c -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo freebsd      CXXFLAGS: -std=c++17
+// #cgo freebsd      LDFLAGS: -L/usr/local/llvm22/lib -lLLVM
+// #cgo linux        CPPFLAGS: -I/usr/include/llvm-22 -I/usr/include/llvm-c-22 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+// #cgo linux        CXXFLAGS: -std=c++17
+// #cgo linux        LDFLAGS: -L/usr/lib/llvm-22/lib -lLLVM-22
+import "C"
+
+type run_build_sh int


### PR DESCRIPTION
## Summary

- add the `llvm22` cgo configuration for Darwin, FreeBSD, and Linux
- exclude `llvm22` from the LLVM 19 default fallback so the tag cannot silently select LLVM 19
- add LLVM 22 to the Linux and macOS CI matrices
- update the documented supported-version list, including the previously omitted LLVM 21

## Testing

- `go test -tags=llvm22 ./...`
- `go vet -tags=llvm22 ./...`

Tested locally with Homebrew LLVM 22.1.8.